### PR TITLE
Modules support permissionmanager

### DIFF
--- a/docs/modules/home.md
+++ b/docs/modules/home.md
@@ -17,11 +17,11 @@ By default, all users will only be able to set one home. This can be changed by 
 setting options.
 
 You can set an arbitary number of homes by setting the option `home-count` to the number of homes you wish the player/group
-to have. If you are using PermissionsEx, you can set the number of homes on a player using the command:
+to have. 
 
-You can set the number of homes on a player with a command
+If you are using PermissionsEx or PermissionManager, you can do it with a command.
  - PermissionsEx: `/pex user {user} option home-count {number}`
- - PermissionManager: `/pm users {users} set option home-count {number}`
+ - PermissionManager: `/pm users {users} set option home-count {number}` or `/pm groups {group} set option home-count {number}`
 
 Consult the permissions plugin's documentation for more information on how to do this. If you wish a player to have an
 unlimted number of homes, set the permission `nucleus.home.set.unlimted`.

--- a/docs/modules/home.md
+++ b/docs/modules/home.md
@@ -9,7 +9,7 @@ modulename: Home
 ## Introduction
 
 The Home module provides the ability for players to set personal warps. The number of homes can be limited through the use
-of a compatible permissions plugin, such as PermissionsEx.
+of a compatible permissions plugin, such as PermissionsEx or PermissionManager.
 
 ## Limiting the number of homes
 
@@ -19,7 +19,9 @@ setting options.
 You can set an arbitary number of homes by setting the option `home-count` to the number of homes you wish the player/group
 to have. If you are using PermissionsEx, you can set the number of homes on a player using the command:
 
-`/pex user {user} option home-count {number}`
+You can set the number of homes on a player with a command
+ - PermissionsEx: `/pex user {user} option home-count {number}`
+ - PermissionManager: `/pm users {users} set option home-count {number}`
 
 Consult the permissions plugin's documentation for more information on how to do this. If you wish a player to have an
 unlimted number of homes, set the permission `nucleus.home.set.unlimted`.


### PR DESCRIPTION
Hi,

some people ask me the commands to set the options of Nucleus with PermissionManager. I added how to do it with `home-count`, but before I go further I would like your opinion on how you want I format the text to display the examples of PermissionsEx and PermissionManager.